### PR TITLE
Add .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Don't include anything installed into the virtualenv by pip
+.Python
+bin
+lib
+include
+pip-selfcheck.json
+# We don't need compiled Python artifacts in the repo
+*.pyc
+*.pyo

--- a/pricecalculator/data/.gitignore
+++ b/pricecalculator/data/.gitignore
@@ -1,0 +1,3 @@
+# Don't include the pricedata in the git repo - we want to download this
+# instead of working with stale cost data
+*.csv

--- a/pricecalculator/data/ec2/index_metadata.json
+++ b/pricecalculator/data/ec2/index_metadata.json
@@ -1,7 +1,7 @@
 {
     "OfferCode": "AmazonEC2", 
     "FormatVersion": "v1.0", 
-    "Version": "20170324211955", 
-    "Publication Date": "2017-03-24T21:19:55Z", 
+    "Version": "20170605233259", 
+    "Publication Date": "2017-06-05T23:32:59Z", 
     "Disclaimer": "This pricing list is for informational purposes only. All prices are subject to the additional terms included in the pricing pages on http://aws.amazon.com. All Free Tier prices are also subject to the terms included at https://aws.amazon.com/free/"
 }

--- a/pricecalculator/data/lambda/index_metadata.json
+++ b/pricecalculator/data/lambda/index_metadata.json
@@ -1,7 +1,7 @@
 {
     "OfferCode": "AWSLambda", 
     "FormatVersion": "v1.0", 
-    "Version": "20161207235208", 
-    "Publication Date": "2016-12-07T23:52:08Z", 
+    "Version": "20170607184100", 
+    "Publication Date": "2017-06-07T18:41:00Z", 
     "Disclaimer": "This pricing list is for informational purposes only. All prices are subject to the additional terms included in the pricing pages on http://aws.amazon.com. All Free Tier prices are also subject to the terms included at https://aws.amazon.com/free/"
 }

--- a/pricecalculator/data/rds/index_metadata.json
+++ b/pricecalculator/data/rds/index_metadata.json
@@ -1,7 +1,7 @@
 {
     "OfferCode": "AmazonRDS", 
     "FormatVersion": "v1.0", 
-    "Version": "20170327042929", 
-    "Publication Date": "2017-03-27T04:29:29Z", 
+    "Version": "20170607003505", 
+    "Publication Date": "2017-06-07T00:35:05Z", 
     "Disclaimer": "This pricing list is for informational purposes only. All prices are subject to the additional terms included in the pricing pages on http://aws.amazon.com. All Free Tier prices are also subject to the terms included at https://aws.amazon.com/free/"
 }

--- a/pricecalculator/data/s3/index_metadata.json
+++ b/pricecalculator/data/s3/index_metadata.json
@@ -1,7 +1,7 @@
 {
     "OfferCode": "AmazonS3", 
     "FormatVersion": "v1.0", 
-    "Version": "20170329010048", 
-    "Publication Date": "2017-03-29T01:00:48Z", 
+    "Version": "20170424230114", 
+    "Publication Date": "2017-04-24T23:01:14Z", 
     "Disclaimer": "This pricing list is for informational purposes only. All prices are subject to the additional terms included in the pricing pages on http://aws.amazon.com. All Free Tier prices are also subject to the terms included at https://aws.amazon.com/free/"
 }


### PR DESCRIPTION
* Add a `.gitignore` file to keep git from complaining about directories added when you set up the virtualenv
* Add a `.gitignore` in *pricecalculator/data* tree so git won't display all the cost json files when you download fresh AWS pricing information.